### PR TITLE
Add protocol to the `PhWorkChain`

### DIFF
--- a/src/aiida_quantumespresso_ph/calculations/functions/recollect_qpoints.py
+++ b/src/aiida_quantumespresso_ph/calculations/functions/recollect_qpoints.py
@@ -27,7 +27,7 @@ def recollect_qpoints(**kwargs):
         index = key.split('_')[-1]
         filepath_src = dynmat_prefix
         filepath_dst = f'{dynmat_prefix}{index}'
-        
+
         if int(index) == 0:
             with retrieved_folder.base.repository.open(filepath_dst, 'rb') as handle:
                 merged_folder.base.repository.put_object_from_filelike(handle, filepath_dst)


### PR DESCRIPTION
Since the inputs of the `PhWorkChain` are almost identical to those
of the `PhBaseWorkChain`, the `get_builder_from_protocol()` method 
leverages that of the `PwBaseWorkChain` and simply overrides the 
process class.